### PR TITLE
Fix plugin use of de::SeqVisitor

### DIFF
--- a/serde2/serde2_macros/src/lib.rs
+++ b/serde2/serde2_macros/src/lib.rs
@@ -832,7 +832,7 @@ fn deserialize_struct_empty_fields(
 
             #[inline]
             fn visit_seq<V>(&mut self, mut visitor: V) -> Result<$type_ident, V::Error>
-                where V: de::SeqVisitor,
+                where V: ::serde2::de::SeqVisitor,
             {
                 try!(visitor.end());
                 self.visit_unit()


### PR DESCRIPTION
When compiling a module with a struct containing a derive_deserialize 
annotation, the compiler was complaining "Use of undeclared type or module
`de`".