### PR TITLE
Remove `impl Into<Vec<u8>> for ByteBuf` since it causes a compile error

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -97,12 +97,6 @@ impl AsMut<[u8]> for ByteBuf {
     }
 }
 
-impl Into<Vec<u8>> for ByteBuf {
-    fn into(self) -> Vec<u8> {
-        self.bytes
-    }
-}
-
 impl ops::Deref for ByteBuf {
     type Target = [u8];
 


### PR DESCRIPTION
As @BurntSushi observes, there is an `impl<T, U> Into<U> for T where U: From<T>`
in libcore. We have `From<Vec<u8>>` for `ByteBuf` since we have implemented
`From<T> for ByteBuf where T: Into<Vec<u8>>`, so this is redundant anyway.