### PR TITLE
Add doc link to Cargo.toml and doc attr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A serialization/deserialization framework"
 repository = "https://github.com/erickt/rust-serde"
+documentation = "http://erickt.github.io/rust-serde/serde"
 
 [dependencies]
 num = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! handshake protocol between serializers and serializees can be completely optimized away,
 //! leaving serde to perform roughly the same speed as a hand written serializer for a specific
 //! type.
+#![doc(html_root_url="http://erickt.github.io/rust-serde")]
 
 extern crate num;
 


### PR DESCRIPTION
The attribute allows cross-crate rustdoc links.